### PR TITLE
GitHub連携ログイン

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -102,4 +102,9 @@ ANALYTICS_ID=UA-xxxxxxxx-1
 
 #Yahoo
 YAHOO_TAG_ID=xxxxxxx
+
+#GitHub
+GITHUB_KEY=xxxxxxx
+GITHUB_SECRET=xxxxxxxxxxxxxx
+
 EXPLAINE=["日本国内法人運営","Amazon Web Services上で運用"]

--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,9 @@ gem 'browserify-rails'
 gem 'autoprefixer-rails'
 
 # Added by Kibousoft
+gem 'omniauth'
 gem 'omniauth-facebook'
+gem 'omniauth-github'
 gem 'react-rails-img'
 gem 'json'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -269,6 +269,9 @@ GEM
       rack (>= 1.6.2, < 3)
     omniauth-facebook (4.0.0)
       omniauth-oauth2 (~> 1.2)
+    omniauth-github (1.2.3)
+      omniauth (~> 1.5)
+      omniauth-oauth2 (>= 1.4.0, < 2.0)
     omniauth-oauth2 (1.4.0)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
@@ -527,7 +530,9 @@ DEPENDENCIES
   mysql2
   nokogiri
   oj
+  omniauth
   omniauth-facebook
+  omniauth-github
   ostatus2 (~> 1.1)
   ox
   paperclip (~> 5.1)

--- a/app/assets/stylesheets/oauth.scss
+++ b/app/assets/stylesheets/oauth.scss
@@ -1,15 +1,57 @@
 .oauth-signup {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   padding: 10px;
   margin: 20px;
   text-align: center;
+
+  .login-buttons-box {
+    width: 300px;
+  }
+}
+
+.oauth-signin {
+  margin-top: 30px;
+
+  h3 {
+    font-family: 'Montserrat', sans-serif;
+    font-size: 20px;
+    line-height: 28px;
+    font-weight: 400;
+    margin-bottom: 20px;
+    color: $color2;
+  }
+
 }
 
 .facebook-login-button {
-  width: 300px;
   height: 40px;
   color: white;
   font-size: 20px;
   background-color: #3b5998;
   border: none;
   border-radius: 5px;
+}
+
+.github-login-button {
+  width: 300px;
+  height: 40px;
+  color: white;
+  font-size: 20px;
+  background-color: gray;
+  border: none;
+  border-radius: 5px;
+}
+
+.login-button-list {
+  list-style: none !important;
+  margin: 0 !important;
+
+  li {
+    margin-top: 10px;
+    button {
+      width: 100%;
+    }
+  }
 }

--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -3,6 +3,12 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     # You need to implement the method below in your model (e.g. app/models/user.rb)
     @user = User.from_omniauth(request.env["omniauth.auth"])
 
+    if @user.errors.any?
+      reason = @user.errors.full_messages.join(' / ')
+      set_flash_message(:alert, :failure, kind: "Facebook", reason: reason)
+      redirect_to new_user_session_path and return
+    end
+
     if @user.present?
       p "Login Success"
       sign_in @user

--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -14,6 +14,16 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     end
   end
 
+  def github
+    @user = User.from_omniauth(request.env["omniauth.auth"])
+
+    if @user.present?
+      sign_in @user
+      set_flash_message(:notice, :success, :kind => "GitHub") if is_navigational_format?
+      redirect_to root_path and return
+    end
+  end
+
   def failure
     redirect_to root_path
   end

--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -22,6 +22,10 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       set_flash_message(:notice, :success, :kind => "GitHub") if is_navigational_format?
       redirect_to root_path and return
     end
+
+    failure_reason = if @user.errors.any? @user.errors.full_messages.join(' / '); else nil end
+    set_flash_message(:notice, :failure, kind: "GitHub", reason: failure_reason)
+    redirect_to new_user_session_path
   end
 
   def failure

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,6 +36,7 @@ class User < ApplicationRecord
     uid = auth['uid']
     provider = auth['provider']
     email = auth['info']['email'] || ''
+    avator_url = auth['info']['image'] || ''
 
     username = omniauth_username provider, uid
     display_name = auth['info']['name'] || auth['info']['nickname'] || username
@@ -47,6 +48,7 @@ class User < ApplicationRecord
       user.password_confirmation = password
       user.skip_confirmation!
       user.create_account(username: username, display_name: display_name)
+      user.account.avatar_remote_url = avator_url if avator_url
     end
     user
   end

--- a/app/views/about/show.html.haml
+++ b/app/views/about/show.html.haml
@@ -41,11 +41,15 @@
 
   %h3= "ソーシャルログイン"
   .oauth-signup
-    = link_to button_tag("facebook", class: "facebook-login-button"), user_facebook_omniauth_authorize_path
-    %br
-    facebook認証するだけで、自動で会員登録できます。
-    %br
-    facebookのタイムラインに無断で投稿することはありません。
+    %div.login-buttons-box
+      %ul.login-button-list
+        %li
+          = link_to button_tag("facebook", class: "facebook-login-button")  , user_facebook_omniauth_authorize_path
+        %li
+          = link_to button_tag("github", class: "github-login-button")  , user_github_omniauth_authorize_path
+    認証するだけで、自動で会員登録できます。
+    %brタイムラインに無断で投稿することはありません。
+
   %h3 このインスタンスの特徴
 
   .features-list

--- a/app/views/auth/sessions/new.html.haml
+++ b/app/views/auth/sessions/new.html.haml
@@ -8,5 +8,12 @@
   .actions
     = f.button :button, t('auth.login'), type: :submit
 
-= link_to button_tag("Log in with facebook", class: "facebook-login-button")  , user_facebook_omniauth_authorize_path
+%div.oauth-signin
+  %h3= "ソーシャルログイン"
+  %ul.login-button-list
+    %li
+      = link_to button_tag("Log in with facebook", class: "facebook-login-button")  , user_facebook_omniauth_authorize_path
+    %li
+      = link_to button_tag("Log in with github", class: "github-login-button")  , user_github_omniauth_authorize_path
+
 .form-footer= render "auth/shared/links"

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -245,6 +245,7 @@ Devise.setup do |config|
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
   config.omniauth :facebook, ENV['FACEBOOK_APP_ID'], ENV['FACEBOOK_APP_SECRET'],
                   callback_url: ENV['FACEBOOK_CALLBACK_URL']
+  config.omniauth :github, ENV['GITHUB_KEY'], ENV['GITHUB_SECRET'], scope: 'user:email'
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -25,7 +25,7 @@ ja:
       unlock_instructions:
         subject: 'Mastodon: アカウントのロックの解除'
     omniauth_callbacks:
-      failure: '%{reason}によって%{kind}からのアクセスを認証できませんでした。'
+      failure: '%{kind}からのアクセスを認証できませんでした。%{reason}'
       success: '%{kind}からのアクセスは正常に認証されました。'
     passwords:
       no_token: パスワード再発行のメール以外からこのページにアクセスすることはできません。 パスワード再発行のメールからアクセスしたのにもかかわらずこのメッセージが表示される場合は、アクセスしたURLが間違っていないか確認してください。


### PR DESCRIPTION
## 注記
* production環境下での動作確認
* githubアクセストークンを別途設定する必要あり 

## 作業内容
* omniauth-github実装。ログイン成功によりホーム画面へ、失敗によりログイン画面へリダイレクト
* アカウント作成失敗時、ActiveRecordのエラーメッセージを表示
* アカウント認証成功時、アカウントのアバターがあれば取得 (リモートフォロー用の実装を流用)
* Facebook認証の内部処理をリファクタリング (共通処理の実装による)
