### PR TITLE
IcoRequestにcampaign_nameを保存する

### DIFF
--- a/app/controllers/ico_requests_controller.rb
+++ b/app/controllers/ico_requests_controller.rb
@@ -13,6 +13,7 @@ class IcoRequestsController < ApplicationController
   # GET /ico_requests/new
   def new
     @ico_request = IcoRequest.new
+    @ico_request.campaign_name = params[:campaign]
   end
 
   # GET /ico_requests/1/edit
@@ -22,7 +23,7 @@ class IcoRequestsController < ApplicationController
   # POST /ico_requests
   def create
     unless ico_request_check_params[:check_1] && ico_request_check_params[:check_3] && ico_request_check_params[:check_4]
-      redirect_to new_ico_requests_path, notice: 'Please check confirm items'
+      redirect_to new_ico_requests_path(campaign: ico_request_params[:campaign_name]), notice: 'Please check confirm items'
       return
     end
     @ico_request = IcoRequest.new(ico_request_params)
@@ -63,7 +64,7 @@ class IcoRequestsController < ApplicationController
 
     # Only allow a trusted parameter "white list" through.
     def ico_request_params
-      params.require(:ico_request).permit(:amount, :email, :eth_wallet_address, :token_wallet_address)
+      params.require(:ico_request).permit(:amount, :email, :eth_wallet_address, :token_wallet_address, :campaign_name)
     end
 
     def ico_request_check_params

--- a/app/models/ico_request.rb
+++ b/app/models/ico_request.rb
@@ -11,6 +11,7 @@
 #  token_wallet_address :string
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
+#  campaign_name        :string(100)
 #
 
 class IcoRequest < ApplicationRecord

--- a/app/views/ico_requests/_form.html.haml
+++ b/app/views/ico_requests/_form.html.haml
@@ -37,6 +37,9 @@
       = I18n.t('ico_request.check_4')
       %span.required-mark *
 
+    - if @ico_request.campaign_name.present?
+      = f.hidden_field :campaign_name
+
     = f.button :submit, :class => 'button', id: 'ico-request-submit'
 
   %hr

--- a/db/migrate/20180717052800_add_campaign_name_to_ico_requests.rb
+++ b/db/migrate/20180717052800_add_campaign_name_to_ico_requests.rb
@@ -1,0 +1,5 @@
+class AddCampaignNameToIcoRequests < ActiveRecord::Migration[5.1]
+  def change
+    add_column :ico_requests, :campaign_name, :string, limit: 100
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180514080302) do
+ActiveRecord::Schema.define(version: 20180717052800) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -192,6 +192,7 @@ ActiveRecord::Schema.define(version: 20180514080302) do
     t.string "token_wallet_address"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "campaign_name", limit: 100
   end
 
   create_table "ico_tokens", force: :cascade do |t|


### PR DESCRIPTION
- リクエストパラメータで `campaign=campaign_name` が指定された時にIcoRequestにcampaign_nameが記録されるように変更
- 指定無しの時にはIcoRequestのcampaign_nameはnilになるように変更
- 必須項目にチェックしていない場合とバリデーションエラーになった場合でもcampaign_nameを保持するように変更

備考
- campaign_nameの長さは、無限だと色々怖いのでとりあえず100にしています。
- specはあまりメンテされてなさそう？だったのでひとまず書いていません